### PR TITLE
Add support for OpenResty reverse proxy OIDC Auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 settings.py
 settings_local.py
 settings/local.py
+settings_non_public.py
+settings_public.py
+openresty/conf.d/secrets-public.conf
+openresty/conf.d/secrets-non-public.conf
 *.py[co]
 *.sw[po]
 .coverage

--- a/apache/conf.d/desktop_disk_encrypter_localhost.conf
+++ b/apache/conf.d/desktop_disk_encrypter_localhost.conf
@@ -1,0 +1,23 @@
+Listen 127.0.0.1:5000
+<VirtualHost 127.0.0.1:5000>
+    ServerName desktop_disk_encrypter.mozilla.org
+    ServerAlias wde1-stage.corpdmz.mdc1.mozilla.com wde
+    WSGIScriptAlias / /data/desktop_disk_encrypter/wsgi.py
+    WSGIDaemonProcess desktop_disk_encrypter
+    WSGIProcessGroup desktop_disk_encrypter
+    Alias /static /data/desktop_disk_encrypter/static
+    DocumentRoot /data/desktop_disk_encrypter
+    Alias /static /data/desktop_disk_encrypter/static
+    <Directory /data/desktop_disk_encrypter/static>
+        Require all granted
+    </Directory>
+    <Directory /data/desktop_disk_encrypter>
+        <Files wsgi.py>
+            Require all granted
+        </Files>
+        Options Indexes FollowSymLinks MultiViews
+        AllowOverride None
+        Order allow,deny
+        allow from all
+    </Directory>
+</VirtualHost>

--- a/apache/conf.d/desktop_disk_encrypter_public_localhost.conf
+++ b/apache/conf.d/desktop_disk_encrypter_public_localhost.conf
@@ -1,0 +1,23 @@
+Listen 127.0.0.1:5001
+<VirtualHost 127.0.0.1:5001>
+    ServerName desktop_disk_encrypter.mozilla.org
+    ServerAlias wde1-stage-public.corpdmz.mdc1.mozilla.com wde
+    WSGIScriptAlias / /data/desktop_disk_encrypter_public/wsgi.py
+    WSGIDaemonProcess desktop_disk_encrypter_public
+    WSGIProcessGroup desktop_disk_encrypter_public
+    Alias /static /data/desktop_disk_encrypter_public/static
+    DocumentRoot /data/desktop_disk_encrypter_public
+    Alias /static /data/desktop_disk_encrypter_public/static
+    <Directory /data/desktop_disk_encrypter_public/static>
+        Require all granted
+    </Directory>
+    <Directory /data/desktop_disk_encrypter_public>
+        <Files wsgi.py>
+            Require all granted
+        </Files>
+        Options Indexes FollowSymLinks MultiViews
+        AllowOverride None
+        Order allow,deny
+        allow from all
+    </Directory>
+</VirtualHost>

--- a/apps/moz_desktop/README.md
+++ b/apps/moz_desktop/README.md
@@ -1,0 +1,3 @@
+# moz_desktop
+
+This app is meant to be used by End User Services to administer WDE

--- a/apps/moz_users/README.md
+++ b/apps/moz_users/README.md
@@ -1,0 +1,3 @@
+# moz_users
+
+This app is meant to be used by end users

--- a/apps/site/models.py
+++ b/apps/site/models.py
@@ -28,7 +28,7 @@ class EncryptedDisk(models.Model):
 
     def __unicode__(self):
         try:
-            return "%s - %s" % (self.user.email, str(self.asset_tag))
+            return "%s - %s" % (self.user.username, str(self.asset_tag))
         except:
             return "%s - %s" % (self.email_address, str(self.asset_tag))
 

--- a/apps/site/templates/base.html
+++ b/apps/site/templates/base.html
@@ -3,7 +3,7 @@
 {% load static %}
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
+    <meta charset="UTF-8">
     <title>Recovery Key Locker</title>
     <link rel="stylesheet" href="{% static "bootstrap/css/bootstrap.css" %}" />
     <link rel="stylesheet" href="{% static "bootstrap/css/bootstrap-responsive.css" %}" />
@@ -32,7 +32,7 @@
             {% if user.is_authenticated %}
               <li class="{% active_page request "^\/user\/upload" %}" ><a href="{% url "upload" %}">Upload</a></li>
             {% else %}
-              <li><a href="{% url 'oidc_authentication_init' %}">Login</a></li>
+              <li>This should never display as users are authenticated by openresty</li>
             {% endif %}
             </ul>
           </div><!--/.nav-collapse -->

--- a/apps/site/templates/login.html
+++ b/apps/site/templates/login.html
@@ -1,9 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
 <div class="hero-unit">
-    <h2>Please Login</h2>
-        <a href="{% url 'oidc_authentication_init' %}">
-            <button type="submit" name="submit" id="submit" class="btn btn-primary">Login via OpenIDC</button>
-        </a>
+    This page should never be needed as the user logs in via openresty
 </div>
 {% endblock %}

--- a/middleware/wde/__init__.py
+++ b/middleware/wde/__init__.py
@@ -1,0 +1,13 @@
+from django.contrib.auth.middleware import RemoteUserMiddleware
+from django.conf import settings
+
+class CustomRemoteUserMiddleware(RemoteUserMiddleware):
+    """
+    Middleware for utilizing Web-server-provided authentication.
+
+    This overrides the default META variable configured in RemoteUserMiddleware
+    which is used to fetch the username from and instead uses the META variable
+    defined in the REMOTE_USER_META_VAR setting
+    """
+    header=getattr(
+        settings, 'REMOTE_USER_META_VAR', RemoteUserMiddleware.header)

--- a/oidc/context_processor.py
+++ b/oidc/context_processor.py
@@ -1,4 +1,5 @@
 from django import template
+from django.contrib.auth.middleware import RemoteUserMiddleware
 from django.conf import settings
 
 def has_admin_claim_group(request):
@@ -6,10 +7,14 @@ def has_admin_claim_group(request):
     r_context['has_admin_claim_group'] = False
     try:
         c_group = settings.OIDC_DESKTOP_CLAIM_GROUP
-        if c_group in request.session['claim_groups']:
+
+        # This check is in addition to the check done by openresty and acts as
+        # a redundant check for added security
+        groups = request.META.get(settings.GROUPS_META_VAR,'').split('|')
+        if c_group in groups:
             r_context['has_admin_claim_group'] = True
     except:
-        r_context['has_admin_claim_group'] = True
+        r_context['has_admin_claim_group'] = False
     return r_context
     
 def allow_admin(request):

--- a/openresty/README.md
+++ b/openresty/README.md
@@ -1,0 +1,160 @@
+# Overview
+
+This directory contains configuration files for deploying [OpenResty](https://openresty.org/)
+as well as intructions for deploying WDE in a dual instance model using Openresty
+as an authenticating reverse proxy.
+
+One instance of WDE will be the non-public instance which will surface the administrative
+interface, will bind to port 443 and will be accessed exclusively via VPN on a
+private IP
+
+The other instnace of WDE will be the public instance which will not surface the
+administrative interface, will bind to port 81 and will be fronted by the Zeus
+load balancer which will take care of terminating TLS and forwarding traffic to
+port 81 on the server
+
+# Pre-requisites
+
+* Ensure the server has outbound internet access to the [OpenResty Package Manager](https://opm.openresty.org/)
+  which may require establishing proxy ACLs as in [Bug 1483054](https://bugzilla.mozilla.org/show_bug.cgi?id=1483054)
+* Get rid of the dual network interface cards and IPs as this setup will use a
+  single IP with listeners on two different ports
+* Have Auth0 client_id and client_secrets provisioned for the instances. You'll
+  need these values to configure OpenResty
+
+# Deployment
+
+## Install packages
+
+```
+gpg="gpg --no-default-keyring --secret-keyring /dev/null --keyring /dev/null --no-option --keyid-format 0xlong"
+rm /etc/yum.repos.d/CentOS-*  # https://bugzilla.mozilla.org/show_bug.cgi?id=1329078
+rpmkeys --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+rpm -qi gpg-pubkey-f4a80eb5 | $gpg | grep 0x24C6A8A7F4A80EB5
+rpmkeys --import https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+rpm -qi gpg-pubkey-352c64e5 | $gpg | grep 0x6A2FAEA2352C64E5
+rpmkeys --import https://openresty.org/package/pubkey.gpg
+rpm -qi gpg-pubkey-d5edeb74 | $gpg | grep 0x97DB7443D5EDEB74
+yum-config-manager --add-repo https://openresty.org/package/centos/openresty.repo
+# yum update -y
+yum install -y --setopt=tsflags=nodocs epel-release
+yum install -y --setopt=tsflags=nodocs sudo openssl-devel lua-devel yum-utils openresty openresty-resty openresty-opm python-pip
+opm get zmartzone/lua-resty-openidc
+opm get pintsized/lua-resty-http\>=0.12  # 0.12 or newer is required to support our datacenter http proxies
+```
+
+## Make TLS certs for non-public instance
+
+This is a placeholder for whatever actual cert we'll use on the non-public instance.
+This will be replaced by letsencrypt or digicert or the Mozilla CA.
+
+```
+mkdir -v /usr/local/openresty/nginx/conf/ssl
+openssl_cnf_filename=`mktemp`
+printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth" > $openssl_cnf_filename
+/usr/local/openresty/openssl/bin/openssl req -x509 -out /usr/local/openresty/nginx/conf/ssl/localhost.crt \
+  -keyout /usr/local/openresty/nginx/conf/ssl/localhost.key \
+  -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost' -extensions EXT -config $openssl_cnf_filename
+```
+
+## Deploy the OpenResty configuration files
+
+Run this from the deployed root of this repo
+
+```
+mkdir -v /usr/local/openresty/nginx/conf/conf.d/
+cp openresty/conf.d/* /usr/local/openresty/nginx/conf/conf.d/
+cp openresty/nginx.conf /usr/local/openresty/nginx/conf/
+```
+
+## Deploy the Apache configuration files
+
+Run this from the deployed root of this repo
+
+```
+cp apache/config.d/desktop_disk_encrypter_public_localhost.conf /etc/httpd/conf.d/
+cp apache/config.d/desktop_disk_encrypter_localhost.conf /etc/httpd/conf.d/
+```
+
+In addition to deploying these new Apache configs, you'll need to disable the
+existing configs.
+
+```
+mv -v /etc/httpd/conf.d/00-custom.conf /etc/httpd/conf.d/00-custom.conf.disabled
+mv -v /etc/httpd/conf.d/00-81.conf /etc/httpd/conf.d/00-81.conf.disabled
+mv -v /etc/httpd/conf.d/desktop_disk_encrypter.conf /etc/httpd/conf.d/desktop_disk_encrypter.conf.disabled
+mv -v /etc/httpd/conf.d/ssl.conf /etc/httpd/conf.d/ssl.conf.disabled
+mv -v /etc/httpd/conf.d/desktop_disk_encrypter_ssl.conf /etc/httpd/conf.d/desktop_disk_encrypter_ssl.conf.disabled
+apachectl configtest
+apachectl graceful
+```
+
+If you need to revert this you can run
+
+```
+mv -v /etc/httpd/conf.d/00-custom.conf.disabled /etc/httpd/conf.d/00-custom.conf ; mv -v /etc/httpd/conf.d/00-81.conf.disabled /etc/httpd/conf.d/00-81.conf ; mv -v /etc/httpd/conf.d/desktop_disk_encrypter.conf.disabled /etc/httpd/conf.d/desktop_disk_encrypter.conf ; mv -v /etc/httpd/conf.d/ssl.conf.disabled /etc/httpd/conf.d/ssl.conf ; mv -v /etc/httpd/conf.d/desktop_disk_encrypter_ssl.conf.disabled /etc/httpd/conf.d/desktop_disk_encrypter_ssl.conf
+```
+
+Once you've configured Apache, restart it to bring the new configs live
+
+## Update the Django code
+
+Update the Django code in the two deployed instances with the new code that supports
+OpenResty and uses the RemoteUserBackend
+
+## Configure OpenResty secrets
+
+Create the two secrets files for OpenResty. These files are called
+* `/usr/local/openresty/nginx/conf/conf.d/secrets-non-public.conf`
+* `/usr/local/openresty/nginx/conf/conf.d/secrets-public.conf`
+
+Base them off the `openresty/conf.d/secrets.conf-dist` file's contents
+
+## Configure Django secrets
+
+Create the two Django settings files for the public and non-public instances.
+These files are called
+* `/data/desktop_disk_encrypter/settings_non_public.py`
+* `/data/desktop_disk_encrypter/settings_public.py`
+
+Base them off the `settings_public_or_non_public.py-dist` file's contents
+
+## Start OpenResty
+
+You can start OpenResty manually by running
+
+```
+/usr/bin/openresty -g 'daemon off;'
+```
+
+Or you can create a systemd or init.d file to launch it.
+
+`/usr/bin/openresty` is a symlink to `/usr/local/openresty/nginx/sbin/nginx`.
+
+You can view OpenResty logs with
+
+```
+tail -f /usr/local/openresty/nginx/logs/*.log
+```
+
+# Flows
+
+## Public Instance
+
+* User browses to the WDE DNS name over https which resolves to the IP of a Zeus
+  VIP
+* The Zeus VIP terminates TLS and forwards the connection to the backend server
+  on port 81
+* Listening on port 81 is OpenResty which takes the connection, authenticates
+  user and forward the traffic to 127.0.0.1:5001
+* Listening on 127.0.0.1:5001 is Apache which passes the request to the Django 
+  wsgi server which hosts the public WDE instance
+
+## Non Public Instance
+ 
+* User browses to the internal WDE DNS name over https which resolves to the
+  private IP of the WDE server
+* Listening on port 443 is OpenResty which takes the connection, authenticates
+  user and forward the traffic to 127.0.0.1:5000
+* Listening on 127.0.0.1:5000 is Apache which passes the request to the Django
+  wsgi server which hosts the non-public WDE instance

--- a/openresty/conf.d/headers.conf
+++ b/openresty/conf.d/headers.conf
@@ -1,0 +1,8 @@
+# Default CSP
+add_header Content-Security-Policy "default-src 'none'; img-src 'self'; font-src 'self'; style-src 'self'";
+# Default XCTO
+add_header X-Content-Type-Options nosniff;
+# No iframes
+add_header X-Frame-Options DENY;
+# No XSS
+add_header X-XSS-Protection "1; mode=block";

--- a/openresty/conf.d/nginx_lua.conf
+++ b/openresty/conf.d/nginx_lua.conf
@@ -1,0 +1,19 @@
+## http section configuration that is required for lua-resty-openidc
+# You may want to use your own resolver here. It's necessary for Lua to function.
+# If using a local DNS cache, you should use 127.0.0.1
+
+# resolver 8.8.8.8 8.8.4.4;
+# We have to use a local resolver to be able to resolve the DNS name of the
+# proxy servers configured in proxy_opts in server.lua
+resolver 127.0.0.1;
+
+# The Lua package path is important, and must match your installation/setup.
+# If you get any issue with packages not found in your error logs ("require" failures), add the missing path here.
+lua_package_path '~/lua/?.lua;/usr/share/lua/5.1/?.lua;;';
+lua_package_cpath '/usr/share/lua/5.1/?.so;/usr/lib64/lua/5.1/?.so;;';
+
+lua_ssl_trusted_certificate "/etc/ssl/certs/ca-bundle.crt";
+lua_ssl_verify_depth 5;
+lua_shared_dict discovery 1m;
+lua_shared_dict introspection 15m;
+lua_shared_dict sessions 10m;

--- a/openresty/conf.d/openidc_layer.lua
+++ b/openresty/conf.d/openidc_layer.lua
@@ -1,0 +1,78 @@
+-- Lua reference for nginx: https://github.com/openresty/lua-nginx-module
+-- Lua reference for openidc: https://github.com/zmartzone/lua-resty-openidc
+local oidc = require("resty.openidc")
+local cjson = require( "cjson" )
+
+if not opts then
+  ngx.log(ngx.ERR, "no configuration found")
+end
+opts.client_id = ngx.var.client_id
+opts.client_secret = ngx.var.client_secret
+
+-- Authenticate with lua-resty-openidc if necessary (this will return quickly if no authentication is necessary)
+local res, err, url, session = oidc.authenticate(opts)
+
+-- Check if authentication succeeded, otherwise kick the user out
+if err then
+  if session ~= nil then
+    session:destroy()
+  end
+  ngx.redirect(opts.logout_path)
+end
+-- If you want all claims as headers, use this
+-- local function build_headers(t, name)
+--   for k,v in pairs(t) do
+--     -- unpack tables
+--     if type(v) == "table" then
+--       local j = cjson.encode(v)
+--       ngx.req.set_header("OIDC_CLAIM_"..name..k, j)
+--     else
+--       ngx.req.set_header("OIDC_CLAIM_"..name..k, tostring(v))
+--     end
+--   end
+-- end
+
+-- build_headers(session.data.id_token, "ID_TOKEN_")
+-- build_headers(session.data.user, "USER_PROFILE_")
+
+-- Set most useful headers with user info and OIDC claims for the underlaying web application to use
+-- These header names are voluntarily similar to Apaches mod_auth_openidc and other modules,
+-- but may of course be modified
+ngx.req.set_header("REMOTE_USER", session.data.user.email)
+ngx.req.set_header("X-Forwarded-User", session.data.user.email)
+ngx.req.set_header("OIDC_CLAIM_ACCESS_TOKEN", session.data.access_token)
+ngx.req.set_header("OIDC_CLAIM_ID_TOKEN", session.data.enc_id_token)
+ngx.req.set_header("via",session.data.user.email)
+
+-- Flatten groups for apps that won't read JSON
+local grps = false
+local usergrp = ""
+if session.data.user.groups then
+    usergrp = session.data.user.groups
+elseif session.data.user['https://sso.mozilla.com/claim/groups'] then
+    usergrp = session.data.user['https://sso.mozilla.com/claim/groups']
+end
+if usergrp ~= "" and usergrp ~= nil then
+    for k,v in pairs(usergrp) do
+      grps = (grps and grps.."|"..v) or v  -- If grps is false, set grps to v, otherwise append "|v" to grps
+    end
+end
+ngx.req.set_header("X-Forwarded-Groups", grps)
+
+-- Access control: only allow specific users in (this is optional, without it all authenticated users are allowed in)
+if ngx.var.allowed_group and ngx.var.allowed_group ~= "" then
+    local authorized = false
+    for _, group in ipairs(usergrp) do
+        if group == ngx.var.allowed_group then
+            authorized = true
+        end
+    end
+
+    if not authorized then
+      ngx.log(ngx.ERR, "Permission denied for user")
+      if session ~= nil then
+        session:destroy()
+      end
+        ngx.redirect(opts.logout_path)
+    end
+end

--- a/openresty/conf.d/secrets.conf-dist
+++ b/openresty/conf.d/secrets.conf-dist
@@ -1,0 +1,8 @@
+# allowed_group : Only users in this group will be allowed to access the site
+set $allowed_group 'admins';  # Leave this unset so all users are allowed access
+
+# OIDC client_id
+set $client_id "abcdefgABCDEFG0123456abcdefgABCD";
+
+# OIDC client_secret
+set $client_secret "abcdefgABCDEFG0123456abcdefgABCDabcdefgABCDEFG0123456abcdefgABCD";

--- a/openresty/conf.d/server.conf
+++ b/openresty/conf.d/server.conf
@@ -1,0 +1,92 @@
+init_by_lua_file "/usr/local/openresty/nginx/conf/conf.d/server.lua";
+
+server {
+  listen       81;  # public
+  set $backend "http://127.0.0.1:5001";
+
+  root         /dev/null;
+  error_page   500 502 503 504  /50x.html;
+  location = /50x.html {
+    root       /usr/local/openresty/nginx/html/;
+  }
+  set $session_name "session";
+  set $session.check.ua off;
+  set $session_storage shm;
+  set $session_cookie_persistent on;
+  set $session_cookie_path "/";
+  set $session_check_ssi off;
+  # set $session_secret ;
+  set $session_cookie_samesite off;
+  # Default session to 7 days (604800s), if used with refresh_session_interval or access_token_expires_in
+  # Then session can be rather long (usually 7 to 30 days) since the session will be invalidated when the
+  # user is no longer valid regardless of the cookie's actual expiration.
+  set $session_cookie_lifetime 604800;
+
+  location = /health {
+    return 200;
+    access_log off;
+  }
+
+  # Default location, will enforce authentication there
+  location / {
+    proxy_set_header "X-Forwarded-Proto" "http";
+    proxy_set_header "X-Forwarded-Port" "81";
+    proxy_set_header "X-Forwarded-For" $proxy_add_x_forwarded_for;
+    proxy_set_header "X-Real-IP" $remote_addr;
+    proxy_set_header "Host" $host;
+
+    # Load secrets for the public site
+    include conf.d/secrets-public.conf;
+
+    access_by_lua_file "/usr/local/openresty/nginx/conf/conf.d/openidc_layer.lua";
+    proxy_pass $backend;
+  }
+}
+
+server {
+  listen       443;  # non-public
+  set $backend "http://127.0.0.1:5000";
+
+  ssl on;
+  server_name localhost;
+  ssl_certificate /usr/local/openresty/nginx/conf/ssl/localhost.crt;
+  ssl_certificate_key /usr/local/openresty/nginx/conf/ssl/localhost.key;
+
+  root         /dev/null;
+  error_page   500 502 503 504  /50x.html;
+  location = /50x.html {
+    root       /usr/local/openresty/nginx/html/;
+  }
+  set $session_name "session";
+  set $session.check.ua off;
+  set $session_storage shm;
+  set $session_cookie_persistent on;
+  set $session_cookie_path "/";
+  set $session_check_ssi off;
+  # set $session_secret ;
+  set $session_cookie_samesite off;
+  # Default session to 7 days (604800s), if used with refresh_session_interval or access_token_expires_in
+  # Then session can be rather long (usually 7 to 30 days) since the session will be invalidated when the
+  # user is no longer valid regardless of the cookie's actual expiration.
+  set $session_cookie_lifetime 604800;
+
+  location = /health {
+    return 200;
+    access_log off;
+  }
+
+  # Default location, will enforce authentication there
+  location / {
+    proxy_set_header "X-Forwarded-Proto" "https";
+    proxy_set_header "X-Forwarded-Port" "443";
+    proxy_set_header "X-Forwarded-For" $proxy_add_x_forwarded_for;
+    proxy_set_header "X-Real-IP" $remote_addr;
+    proxy_set_header "Host" $host;
+
+    # Load secrets for the non-public site
+    include conf.d/secrets-non-public.conf;
+
+    access_by_lua_file "/usr/local/openresty/nginx/conf/conf.d/openidc_layer.lua";
+    proxy_pass $backend;
+  }
+}

--- a/openresty/conf.d/server.lua
+++ b/openresty/conf.d/server.lua
@@ -1,0 +1,31 @@
+-- lua-resty-openidc options
+
+-- See also https://github.com/zmartzone/lua-resty-openidc#sample-configuration-for-google-signin for more options
+
+opts = {
+  redirect_uri_path = "/redirect_uri",
+  discovery = "https://auth.mozilla.auth0.com/.well-known/openid-configuration",
+  -- client_id = "",
+  -- client_secret = "",
+  iat_slack = 600,
+  redirect_uri_scheme = "https",
+  logout_path = "/logout",
+  redirect_after_logout_uri = "https://sso.mozilla.com/forbidden",
+  -- The following options are used to verify a user session should be kept running and that the user is still valid
+  -- refresh_session_interval will 302 the user's browser every X amount of seconds (here, 900) transparently
+  -- renew_access_token_on_expiry will use an access or refresh token with a server-side request. If you use the later
+  -- make sure you enable all 3 options: renew_access_token_on_expiry, access_token_expires_in, access_token_expires_leeway
+  -- or understand the consequences of not doing so.
+  --
+  --renew_access_token_on_expiry = true
+  --access_token_expires_in = 900,
+  --access_token_expires_leeway = 60,
+  -- If using renew_access_token_on_expiry you may need a specific scope to request a refresh token
+  --scope = "openid email profile offline_access",
+  scope = "openid email profile",
+  refresh_session_interval = 900,
+  proxy_opts = {
+   http_proxy  = "http://proxy.dmz.mdc1.mozilla.com:3128/",
+   https_proxy = "http://proxy.dmz.mdc1.mozilla.com:3128/"
+  }
+}

--- a/openresty/nginx.conf
+++ b/openresty/nginx.conf
@@ -1,0 +1,21 @@
+worker_processes  1;
+env wde.discovery_url;
+env wde.client_id;
+env wde.client_secret;
+env backend;
+env allowed_group;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       mime.types;
+    default_type  text/html;
+    sendfile        on;
+    keepalive_timeout  65;
+
+    include conf.d/nginx_lua.conf;
+    include conf.d/headers.conf;
+    include conf.d/server.conf;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 django==1.11.10
-mozilla-django-oidc==mozilla-django-oidc==0.6.0

--- a/settings.py-dist
+++ b/settings.py-dist
@@ -1,16 +1,30 @@
 # Django settings for desktop_signing_webapp project.
 
 import os
-import ldap
-from django_auth_ldap.config import LDAPSearch, GroupOfNamesType
+
+from settings_non_public import * # Either "settings_non_public" or "settings_public"
+# This import brings in three settings
+#   ALLOW_ADMIN : Allow users to access the administrative interface
+#   SECRET_KEY : This is used to provide cryptographic signing, and should be set to a unique, unpredictable value.
+#   OIDC_DESKTOP_CLAIM_GROUP : Users must be a member of this group to access the admin site
 
 BASE_DIR = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 PROJECT_DIR = os.path.dirname(BASE_DIR)
 PRIVATE_DIR = os.path.abspath(os.path.join(BASE_DIR, 'private'))
-GPG_KEYRING_FILE = ''
-GPG_KEY_IDS = []
+GPG_KEYRING_FILE = ''  # Path and filename of gpg public keyring
+GPG_KEY_IDS = []  # List of gpg key ids
+HOMEDIR = ''  # Path to homedir for GPG
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
+# ALLOW_ADMIN = False  # This is set in either settings_non_public.py or settings_public.py
+
+REMOTE_USER_HTTP_HEADER_NAME = 'X-Forwarded-User'
+# https://docs.djangoproject.com/en/2.1/ref/request-response/#django.http.HttpRequest.META
+REMOTE_USER_META_VAR="HTTP_%s" % REMOTE_USER_HTTP_HEADER_NAME.upper().replace('-', '_')
+GROUPS_HTTP_HEADER_NAME = 'X-Forwarded-Groups'
+GROUPS_META_VAR="HTTP_%s" % GROUPS_HTTP_HEADER_NAME.upper().replace('-', '_')
+
+ALLOWED_HOSTS=["*"]
 
 ADMINS = (
     # ('Your Name', 'your_email@example.com'),
@@ -21,7 +35,7 @@ MANAGERS = ADMINS
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
-        'NAME': '', 
+        'NAME': '',
         'USER': '',
         'PASSWORD': '',
         'HOST': '',
@@ -29,10 +43,14 @@ DATABASES = {
     }
 }
 
+
+
+# https://docs.djangoproject.com/en/1.11/howto/auth-remote-user/
+# Rely on the upstream authentication provided by a reverse proxy
 AUTHENTICATION_BACKENDS = (
-    'django.contrib.auth.backends.ModelBackend',
-    'oidc.auth.CustomOIDCAuthenticationBackend',
+    'django.contrib.auth.backends.RemoteUserBackend',
 )
+
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.
@@ -92,23 +110,8 @@ STATICFILES_FINDERS = (
 )
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = 'secretkeyhere'
+# SECRET_KEY = ''  # This is set in either settings_non_public.py or settings_public.py
 
-# List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-)
-
-MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'mozilla_django_oidc.middleware.RefreshIDToken',
-]
 
 TEMPLATES = [
     {
@@ -116,10 +119,6 @@ TEMPLATES = [
         'APP_DIRS': True,
         'DIRS': '/data/disk_key_encrypter',
         'OPTIONS': {
-#             'loaders': (
-#                 'django.template.loaders.filesystem.Loader',
-#                 'django.template.loaders.app_directories.Loader',
-#              ),
              'debug': True,
              'context_processors': [
                  "django.template.context_processors.debug",
@@ -136,6 +135,16 @@ TEMPLATES = [
          }
     },
 ]
+
+MIDDLEWARE = [
+    'django.middleware.common.CommonMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'middleware.wde.CustomRemoteUserMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+]
+
 
 INTERNAL_IPS = ('127.0.0.1',)
 
@@ -158,10 +167,9 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.admin',
-    'mozilla_django_oidc',
 
-    'south',
-    'debug_toolbar',
+    #'south',
+    #'debug_toolbar',
 
 
     # main app
@@ -202,6 +210,11 @@ LOGGING = {
 
 SOUTH_TESTS_MIGRATE = False
 
-
-
-
+LOGIN_URL = '/login/'
+DBS_OPTIONS = {
+        'table': 'binary_blob',
+        'base_url': '/administration/attach/',
+    }
+PAGINATION_LENGTH=5
+HOMEDIR='/gpg'
+PROG_NAME = 'DESKTOP_DISK_ENCRYPTER'

--- a/settings_public_or_non_public.py-dist
+++ b/settings_public_or_non_public.py-dist
@@ -1,0 +1,10 @@
+# Django settings for public instance of the WDE desktop_disk_encrypter project.
+
+# Allow users to access the administrative interface
+ALLOW_ADMIN = True
+
+# This is used to provide cryptographic signing, and should be set to a unique, unpredictable value.
+SECRET_KEY = ''
+
+# Users must be a member of this group to access the admin site
+OIDC_DESKTOP_CLAIM_GROUP = ''

--- a/urls.py
+++ b/urls.py
@@ -6,19 +6,16 @@ from apps.site.views import login_view
 from apps.moz_users.views import upload
 from django.conf import settings
 
+# URLs accessible on any Django instance
+urlpatterns = [
+    url(r'^user/', include('apps.moz_users.urls')),
+    url(r"^login[/]", login_view, name="login"),
+    url(r'^$', upload),
+]
+
+# URLs only accessible on a non-public Django instance
 if settings.ALLOW_ADMIN:
-    urlpatterns = [
-        url(r'^user/', include('apps.moz_users.urls')),
-        url(r"^login[/]", login_view, name="login"),
-        url(r'^oidc/', include('mozilla_django_oidc.urls')),
-        url(r'^$', upload),
+    urlpatterns.extend([
         url(r'^administration/', include('apps.moz_desktop.urls')),
         url(r'^admin/', include(admin.site.urls)),
-    ]
-else:
-    urlpatterns = [
-        url(r'^user/', include('apps.moz_users.urls')),
-        url(r"^login[/]", login_view, name="login"),
-        url(r'^oidc/', include('mozilla_django_oidc.urls')),
-        url(r'^$', upload),
-    ]
+    ])


### PR DESCRIPTION
This changes WDE to use an OpenResty reverse proxy
for authentication and RemoteUserMiddleware to pass
the authentication results on to Django.

Documentation can be found in the openresty/README.md