### PR TITLE
Account for missing or empty GROUPS_META_VAR settings

### DIFF
--- a/apps/moz_desktop/views.py
+++ b/apps/moz_desktop/views.py
@@ -19,7 +19,8 @@ def user_has_claim(func):
     def wrap(request, *args, **kwargs):
         # This check is in addition to the check done by OpenResty and acts as
         # a redundant check for added security
-        groups = request.META.get(settings.GROUPS_META_VAR, '').split('|')
+        groups_header = request.META.get(settings.GROUPS_META_VAR, '')
+        groups = groups_header.split('|') if groups_header else []
         if (hasattr(request, 'user') and request.user.is_authenticated()
                 and settings.OIDC_DESKTOP_CLAIM_GROUP in groups):
             return func(request, *args, **kwargs)

--- a/oidc/context_processor.py
+++ b/oidc/context_processor.py
@@ -10,7 +10,8 @@ def has_admin_claim_group(request):
 
         # This check is in addition to the check done by openresty and acts as
         # a redundant check for added security
-        groups = request.META.get(settings.GROUPS_META_VAR, '').split('|')
+        groups_header = request.META.get(settings.GROUPS_META_VAR, '')
+        groups = groups_header.split('|') if groups_header else []
         if c_group in groups:
             r_context['has_admin_claim_group'] = True
     except:


### PR DESCRIPTION
This more gracefully deals with scenarios where
* GROUPS_META_VAR isn't set
* GROUPS_META_VAR is set to an empty string

Now these scenarios result in an empty list instead of ['']
This in turn protects against setting OIDC_DESKTOP_CLAIM_GROUP
to an empty string and GROUPS_META_VAR to an empty string and
as a result allowing everyone in